### PR TITLE
fix: folder deletion

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const forceDel = (file, cwd) =>
 module.exports = (patterns, { cwd = process.cwd() } = {}) => {
   const mapper = file => forceDel(file, cwd);
 
-  return globby(patterns, { cwd })
+  return globby(patterns, { cwd, nodir: false })
     .then(files => pMap(files, mapper))
     .then(res => [].concat(...res));
 };

--- a/test.js
+++ b/test.js
@@ -15,6 +15,16 @@ const setupRepo = async cwd => {
 };
 
 describe('in temp dir', () => {
+  it('removes folder', async () => {
+    expect.assertions(1);
+    const tmpPath = f.copy('fixtures');
+
+    await setupRepo(tmpPath);
+    await forceDel('nested', { cwd: tmpPath });
+
+    expect(pathExistsSync(join(tmpPath, 'nested'))).toBe(false);
+  });
+
   it('removes files from git repo', async () => {
     expect.assertions(3);
     const tmpPath = f.copy('fixtures');
@@ -49,6 +59,17 @@ describe('in `process.cwd()`', () => {
   afterEach(() => {
     // Move the process back to the real `process.cwd()`
     process.chdir(realCWD);
+  });
+
+  it('removes folder', async () => {
+    expect.assertions(1);
+    const tmpPath = f.copy('fixtures');
+    process.chdir(tmpPath);
+
+    await setupRepo(tmpPath);
+    await forceDel('nested');
+
+    expect(pathExistsSync(join(tmpPath, 'nested'))).toBe(false);
   });
 
   it('removes files from git repo', async () => {

--- a/test.js
+++ b/test.js
@@ -15,7 +15,7 @@ const setupRepo = async cwd => {
 };
 
 describe('in temp dir', () => {
-  it('removes folder', async () => {
+  it('deletes folder', async () => {
     expect.assertions(1);
     const tmpPath = f.copy('fixtures');
 
@@ -25,7 +25,7 @@ describe('in temp dir', () => {
     expect(pathExistsSync(join(tmpPath, 'nested'))).toBe(false);
   });
 
-  it('removes files from git repo', async () => {
+  it('deletes files from git repo', async () => {
     expect.assertions(3);
     const tmpPath = f.copy('fixtures');
 
@@ -39,7 +39,7 @@ describe('in temp dir', () => {
     );
   });
 
-  it('removes files from general file-system', async () => {
+  it('deletes files from general file-system', async () => {
     expect.assertions(3);
     const tmpPath = f.copy('fixtures');
 
@@ -61,7 +61,7 @@ describe('in `process.cwd()`', () => {
     process.chdir(realCWD);
   });
 
-  it('removes folder', async () => {
+  it('deletes folder', async () => {
     expect.assertions(1);
     const tmpPath = f.copy('fixtures');
     process.chdir(tmpPath);
@@ -72,7 +72,7 @@ describe('in `process.cwd()`', () => {
     expect(pathExistsSync(join(tmpPath, 'nested'))).toBe(false);
   });
 
-  it('removes files from git repo', async () => {
+  it('deletes files from git repo', async () => {
     expect.assertions(3);
     const tmpPath = f.copy('fixtures');
     process.chdir(tmpPath);
@@ -87,7 +87,7 @@ describe('in `process.cwd()`', () => {
     );
   });
 
-  it('removes files from general file-system', async () => {
+  it('deletes files from general file-system', async () => {
     expect.assertions(3);
     const tmpPath = f.copy('fixtures');
     process.chdir(tmpPath);


### PR DESCRIPTION
Now `force-del` can process patterns that matched folder name